### PR TITLE
version downgrade for intake

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.10
-  - intake
+  - intake=0.6.5
   - pre-commit
   - matplotlib
   - numpy


### PR DESCRIPTION

Intake version downgraded to `0.6.5` from 0.6.6 due to the below error encountered on M1
(might be OS specific)

```shell
>>> import intake
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/sayantikabanik/miniforge3/envs/journey/lib/python3.10/site-packages/intake/__init__.py", line 90, in <module>
    make_open_functions()
  File "/Users/sayantikabanik/miniforge3/envs/journey/lib/python3.10/site-packages/intake/__init__.py", line 77, in make_open_functions
    for name in drivers.enabled_plugins():
  File "/Users/sayantikabanik/miniforge3/envs/journey/lib/python3.10/site-packages/intake/source/discovery.py", line 94, in enabled_plugins
    for ep in self.from_entrypoints() + self.from_conf():
  File "/Users/sayantikabanik/miniforge3/envs/journey/lib/python3.10/site-packages/intake/source/discovery.py", line 60, in from_conf
    return [
  File "/Users/sayantikabanik/miniforge3/envs/journey/lib/python3.10/site-packages/intake/source/discovery.py", line 64, in <listcomp>
    object_name=v.rsplit(":", 1)[1] if ":" in v else v.rsplit(".", 1)[1]

```