### PR TITLE
GHA: Update for default permissions

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 
 # Declare default permissions as read only.
-permissions: read-all
+permissions: read
 
 jobs:
   analysis:


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration by changing the default permissions declaration.

* [`.github/workflows/scorecard.yml`](diffhunk://#diff-2e3112f4e81a9c47df8000638ce3b1b9ca15edcc82b228c207a7a4ff3bc7133fL19-R19): Changed the default permissions from `read-all` to `read` to align with GitHub's standard permission naming.