### PR TITLE
Document DeepEval-based LLM evaluation workflow in README #208

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Each layer has a certain strength of communication inbuilt
 | ✅      | `Web UI` re-done and expanded with [FastHTML](https://docs.fastht.ml/)                                                                   | Web Application               |
 | ✅      | `Vale.sh` configured at PR level                                                                                                         | Docs Linting                  |
 | ✅      | `Query engine` for LLM application using [Chromadb](https://docs.trychroma.com/docs/overview/introduction)                               | Vector Retrieval              |
+| ✅      | `LLM Evaluation & Tracing` for data analysis pipelines using [DeepEval](https://deepeval.com/docs/getting-started)                       | LLM Evaluation                | 
 
 
 ### ☕️ Quickly getting started with DataJourney


### PR DESCRIPTION
## **Issue:** Document DeepEval-based LLM evaluation workflow in README #208
- updated workflow table in readme with deepeval llm evaluation entry 

- The entry now clearly shows that DataJourney supports LLM evaluation and tracing capabilities using DeepEval, making it easier for users to discover this workflow. The scripts in `evaluate_llm` include:

    - `evalute_data_analysis_pipeline.py`

    - `trace_setup_github_models.py`

    
That's all for now! The Journey Type, as per my understanding is what the workflow does so if any changes are needed, please do let me know! 