### PR TITLE
GHA for Release Tag Sync

### DIFF
--- a/.github/workflows/release-version-sync.yml
+++ b/.github/workflows/release-version-sync.yml
@@ -1,0 +1,74 @@
+name: Release Version Sync
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to set (e.g., 1.0.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: get_version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RELEASE_VERSION="${{ github.event.inputs.version }}"
+          else
+            RELEASE_VERSION=${GITHUB_REF#refs/tags/v}
+          fi
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $RELEASE_VERSION"
+
+      - name: Update setup.py
+        run: |
+          RELEASE_VERSION="${{ steps.get_version.outputs.RELEASE_VERSION }}"
+          sed -i "s/RELEASE_VERSION = os.getenv(\"RELEASE_VERSION\", \".*\")/RELEASE_VERSION = os.getenv(\"RELEASE_VERSION\", \"$RELEASE_VERSION\")/" setup.py
+          echo "Updated setup.py with version $RELEASE_VERSION"
+
+      - name: Update pixi.toml
+        run: |
+          RELEASE_VERSION="${{ steps.get_version.outputs.RELEASE_VERSION }}"
+          sed -i "s/^version = \".*\"/version = \"$RELEASE_VERSION\"/" pixi.toml
+          echo "Updated pixi.toml with version $RELEASE_VERSION"
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          git diff --exit-code setup.py pixi.toml || echo "CHANGED=true" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        if: steps.check_changes.outputs.CHANGED == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: bump version to ${{ steps.get_version.outputs.RELEASE_VERSION }}"
+          title: "chore: Release version ${{ steps.get_version.outputs.RELEASE_VERSION }}"
+          body: |
+            Automated version update for release ${{ steps.get_version.outputs.RELEASE_VERSION }}
+            
+            This PR updates:
+            - setup.py default version
+            - pixi.toml project version
+            
+            Triggered by: ${{ github.event_name == 'workflow_dispatch' && 'Manual workflow dispatch' || format('Tag push: {0}', github.ref) }}
+          branch: release/v${{ steps.get_version.outputs.RELEASE_VERSION }}
+          base: main
+          labels: |
+            automated
+            release

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Each layer has a certain strength of communication inbuilt
 | ✅      | `Web UI` re-done and expanded with [FastHTML](https://docs.fastht.ml/)                                                                   | Web Application               |
 | ✅      | `Vale.sh` configured at PR level                                                                                                         | Docs Linting                  |
 | ✅      | `Query engine` for LLM application using [Chromadb](https://docs.trychroma.com/docs/overview/introduction)                               | Vector Retrieval              |
+| ✅      | `LLM Evaluation & Tracing` for data analysis pipelines using [DeepEval](https://deepeval.com/docs/getting-started)                       | LLM Evaluation                | 
 
 
 ### ☕️ Quickly getting started with DataJourney
@@ -104,7 +105,21 @@ Each layer has a certain strength of communication inbuilt
 | `DJ_sync_dataset_trees`      | Downloads and synchronizes the `trees.csv` dataset into the project structure.                               |
 | `DJ_chromadb_gen_embedding`  | Query engine for LLM applications                                                                            |
 | `DJ_RAG_without_memory`      | End-to-end Retrieval-Augmented Generation (RAG) pipeline                                                     |
-| `DJ_prompt_enhancer`         | How to design a simple prompt enhancer using gpt-oss-120b |
+| `DJ_prompt_enhancer`         | How to design a simple prompt enhancer using gpt-oss-120b                                                    |
+
+
+### 🔄 Version Management
+
+DataJourney uses automated version syncing via GitHub Actions. When you push a release tag, the workflow automatically updates `setup.py` and `pixi.toml` versions and creates a PR.
+
+**Usage:**
+```bash
+# Create and push a release tag
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+The workflow will automatically create a PR with version updates.
 
 
 ### 🔌 About pre-commit-hooks and activating

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,16 @@
 Package manager for analytics_framework
 """
 
+import os
 from setuptools import find_packages, setup
+
+# Read version from environment variable with fallback
+#this is for if the workflow fails to pass the version
+RELEASE_VERSION = os.getenv("RELEASE_VERSION", "2.0.0")
 
 setup(
     name="analytics_framework",
-    version="2.0.0",
+    version=RELEASE_VERSION,
     author="sayantikabanik",
     description="Design first open source data management toolkit",
     long_description=open("README.md").read(),


### PR DESCRIPTION
## **Issue:** GHA for Release Tag sync #179 
Created a Github Action file for release version update.
- kindly ignore the first commit for version update logic because that has been corrected to now only include GHA `.yml` file.
- GitHub Action file for updating both `setup.py`  and `pixi.toml`
- Fallback added in `setup.py` to use environment variable in case the workflow fails somehow.
- I dunno `.toml` doesn't allow such graceful fallback conditions so no idea what to do there.
- Please let me know if any changes are required!