### PR TITLE
Update triggers for windows-dj-install workflow

### DIFF
--- a/.github/workflows/windows-dj-install.yml
+++ b/.github/workflows/windows-dj-install.yml
@@ -1,6 +1,11 @@
 name: windows-dj-install
 
-on: workflow_dispatch
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request updates the workflow trigger configuration for the `windows-dj-install` GitHub Actions workflow. The workflow will now run on pushes and pull requests to the `main` branch, in addition to manual dispatches.

Workflow trigger updates:

* [`.github/workflows/windows-dj-install.yml`](diffhunk://#diff-54c1b984c6cf6cccbd26cb2ffebb75b6a1bb2c5839ab0c0428175c4eda8cde5aL3-R8): Modified the `on` field to trigger the workflow on `push` and `pull_request` events targeting the `main` branch, as well as on `workflow_dispatch`.