### PR TITLE
Minor:  markdown fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Each layer has a certain strength of communication inbuilt
 ### ☕️ Quickly getting started with DataJourney
 
 - Fork the repository
-- Generate & add `GITHUB_TOKEN`, instructions [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic)\
+- Generate & add `GITHUB_TOKEN`, instructions [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic)
     > Additional requirement to run **LLM based** workflows; Eg: DJ_prompt_enhancer, DJ_llm_analysis, others
 - Switch directory `cd DataJourney`
 - Download pixi : [prefix.dev](https://prefix.dev/)


### PR DESCRIPTION
This pull request makes a minor update to the setup instructions in the `README.md`, specifically improving the formatting of the step for generating and adding a `GITHUB_TOKEN`. The unnecessary trailing backslash has been removed for clarity.